### PR TITLE
Cherry pick of CAS-63 from the user suspension branch

### DIFF
--- a/src/SFA.DAS.Tools.Support.Infrastructure/Services/EmployerCommitmentsService.cs
+++ b/src/SFA.DAS.Tools.Support.Infrastructure/Services/EmployerCommitmentsService.cs
@@ -100,7 +100,9 @@ namespace SFA.DAS.Tools.Support.Infrastructure.Services
                     SearchTerm = request.SearchTerm,
                     StartDate = request.StartDate,
                     EndDate = request.EndDate,
-                    Status = status
+                    Status = status,
+                    PageNumber = 1,
+                    PageItemCount = 99_999 //HACK: The CommitmentsV2 API has a "DownLoad" limit applied to it when you ask for page 0 that returns only apprenticeships with an EndDate within the last 12 months. This hack circumvents having that limit applied
                 }, token);
 
                 return new SearchApprenticeshipsResult

--- a/src/SFA.DAS.Tools.Support.Web/Startup.cs
+++ b/src/SFA.DAS.Tools.Support.Web/Startup.cs
@@ -58,11 +58,19 @@ namespace SFA.DAS.Tools.Support.Web
 
             services.AddControllersWithViews(options =>
             {
-                var policy = new AuthorizationPolicyBuilder()
-                    .RequireAuthenticatedUser()                    
-                    .RequireClaim("http://service/service", _configuration["RequiredRole"])
-                    .Build();
-                options.Filters.Add(new AuthorizeFilter(policy));
+                var policy = new AuthorizationPolicyBuilder();
+
+                if(_env.IsDevelopment())
+                {
+                    policy.RequireAuthenticatedUser();
+                }
+
+                else
+                {
+                    policy.RequireAuthenticatedUser().RequireClaim("http://service/service", _configuration["RequiredRole"]);
+                }
+                    
+                options.Filters.Add(new AuthorizeFilter(policy.Build()));
                 options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute());
             });
             services.AddRazorPages(options =>
@@ -71,8 +79,6 @@ namespace SFA.DAS.Tools.Support.Web
             });
 
             services.AddApplicationInsightsTelemetry(_configuration["APPINSIGHTS_INSTRUMENTATIONKEY"]);
-
-            //services.AddDistributedCache(_configuration, _env);
 
             services.AddSession(options =>
             {
@@ -92,7 +98,6 @@ namespace SFA.DAS.Tools.Support.Web
             else
             {
                 app.UseExceptionHandler("/Home/Error");
-                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
 


### PR DESCRIPTION
Adds code to get around the 12 month limit on data returned from the commitments API when not supplying the paging criteria