### PR TITLE
Fai 838 Integrate DSI sign in with DAS-Tools-Support

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -55,10 +55,10 @@
             "type": "string",
             "defaultValue": "[utcNow()]"
         },
-        "configNames": {
-            "type": "string",
-            "defaultValue": "SFA.DAS.Tools.Support"
-        }
+      "configNames": {
+        "type": "string",
+        "defaultValue": "SFA.DAS.Tools.Support,SFA.DAS.Provider.DfeSignIn"
+      }
     },
     "variables": {
         "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",

--- a/src/SFA.DAS.Tools.Support.UnitTests/SupportControllerTests.cs
+++ b/src/SFA.DAS.Tools.Support.UnitTests/SupportControllerTests.cs
@@ -36,7 +36,7 @@ namespace SFA.DAS.Tools.Support.UnitTests
             Mock<IConfiguration> mockConfig = new Mock<IConfiguration>();
             mockConfig.Setup(x => x.GetSection(It.Is<string>(k => k == "BaseUrl"))).Returns(mockSection.Object);
 
-            SupportController sc = new SupportController(logger, mockConfig.Object, authorizationService.Object);
+            SupportController sc = new SupportController(authorizationService.Object);
             var result = await sc.Index();
 
             var resultModel = result.Should().BeOfType<ViewResult>().
@@ -64,7 +64,7 @@ namespace SFA.DAS.Tools.Support.UnitTests
             Mock<IConfiguration> mockConfig = new Mock<IConfiguration>();
             mockConfig.Setup(x => x.GetSection(It.Is<string>(k => k == "BaseUrl"))).Returns(mockSection.Object);
 
-            SupportController sc = new SupportController(logger, mockConfig.Object, authorizationService.Object);
+            SupportController sc = new SupportController(authorizationService.Object);
             var result = await sc.Index();
 
             var resultModel = result.Should().BeOfType<ViewResult>().

--- a/src/SFA.DAS.Tools.Support.Web/App_Start/AuthenticationExtension.cs
+++ b/src/SFA.DAS.Tools.Support.Web/App_Start/AuthenticationExtension.cs
@@ -1,16 +1,11 @@
-﻿using AutoMapper.Configuration;
-using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+﻿using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.WsFederation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using SFA.DAS.DfESignIn.Auth.AppStart;
-using SFA.DAS.DfESignIn.Auth.Interfaces;
 using SFA.DAS.Tools.Support.Web.Configuration;
 using System;
-using System.Threading.Tasks;
 using SFA.DAS.Tools.Support.Web.Infrastructure;
 using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
 

--- a/src/SFA.DAS.Tools.Support.Web/App_Start/AuthenticationExtension.cs
+++ b/src/SFA.DAS.Tools.Support.Web/App_Start/AuthenticationExtension.cs
@@ -1,44 +1,60 @@
-﻿using Microsoft.AspNetCore.Authentication.Cookies;
+﻿using AutoMapper.Configuration;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authentication.WsFederation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using SFA.DAS.DfESignIn.Auth.AppStart;
+using SFA.DAS.DfESignIn.Auth.Interfaces;
 using SFA.DAS.Tools.Support.Web.Configuration;
 using System;
 using System.Threading.Tasks;
+using SFA.DAS.Tools.Support.Web.Infrastructure;
+using IConfiguration = Microsoft.Extensions.Configuration.IConfiguration;
 
 namespace SFA.DAS.Tools.Support.Web.App_Start
 {
     public static class AuthenticationExtension
     {
+        private const string CookieName = "SFA.DAS.ToolService.Support.Web.Auth";
         public static IServiceCollection AddAuthentication(this IServiceCollection services, IConfiguration configuration)
         {
             var authenticationConfiguration = new AuthenticationConfiguration();
             configuration.GetSection("Authentication").Bind(authenticationConfiguration);
 
-            services.AddAuthentication(options =>
+            var useDfESignIn = configuration.GetValue<bool>("UseDfESignIn");
+
+            if (useDfESignIn)
             {
-                options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = WsFederationDefaults.AuthenticationScheme;
-                options.DefaultSignOutScheme = WsFederationDefaults.AuthenticationScheme;
-            })
-             .AddWsFederation(options =>
-             {
-                 options.Wtrealm = authenticationConfiguration.Wtrealm;
-                 options.MetadataAddress = authenticationConfiguration.MetadataAddress;
-                 options.UseTokenLifetime = false;
-             }).AddCookie(options =>
+                // register DfeSignIn authentication services to the AspNetCore Authentication Options.
+                services.AddAndConfigureDfESignInAuthentication(configuration, $"{CookieName}", typeof(CustomServiceRole));
+            }
+            else
             {
-                options.AccessDeniedPath = new PathString("/Error/403");
-                options.ExpireTimeSpan = TimeSpan.FromHours(1);
-                options.Cookie.Name = "SFA.DAS.ToolService.Support.Web.Auth";
-                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
-                options.SlidingExpiration = true;
-                options.Cookie.SameSite = SameSiteMode.None;
-            });
+                services.AddAuthentication(options =>
+                    {
+                        options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                        options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+                        options.DefaultChallengeScheme = WsFederationDefaults.AuthenticationScheme;
+                        options.DefaultSignOutScheme = WsFederationDefaults.AuthenticationScheme;
+                    })
+                    .AddWsFederation(options =>
+                    {
+                        options.Wtrealm = authenticationConfiguration.Wtrealm;
+                        options.MetadataAddress = authenticationConfiguration.MetadataAddress;
+                        options.UseTokenLifetime = false;
+                    }).AddCookie(options =>
+                    {
+                        options.AccessDeniedPath = new PathString("/Error/403");
+                        options.ExpireTimeSpan = TimeSpan.FromHours(1);
+                        options.Cookie.Name = CookieName;
+                        options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+                        options.SlidingExpiration = true;
+                        options.Cookie.SameSite = SameSiteMode.None;
+                    });
+            }
 
             return services;
         }

--- a/src/SFA.DAS.Tools.Support.Web/Controllers/SupportController.cs
+++ b/src/SFA.DAS.Tools.Support.Web/Controllers/SupportController.cs
@@ -1,10 +1,6 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Authentication.WsFederation;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using SFA.DAS.Tools.Support.Web.Infrastructure;
 using SFA.DAS.Tools.Support.Web.Models;
 
@@ -12,23 +8,10 @@ namespace SFA.DAS.Tools.Support.Web.Controllers
 {
     public class SupportController : Controller
     {
-        private readonly string _baseUrl;
         private IAuthorizationService _authorizationService;
 
-        public SupportController(ILogger<SupportController> logger,
-            IConfiguration _configuration,
-            IAuthorizationService authorizationService)
+        public SupportController(IAuthorizationService authorizationService)
         {
-            var baseUrl = _configuration.GetValue<string>("BaseUrl");
-            if (!baseUrl.EndsWith('/'))
-            {
-                _baseUrl = string.Concat(baseUrl, '/');
-            }
-            else
-            {
-                _baseUrl = baseUrl;
-            }
-
             _authorizationService = authorizationService;
         }
 
@@ -41,20 +24,6 @@ namespace SFA.DAS.Tools.Support.Web.Controllers
             };
 
             return View(indexViewModel);
-        }
-
-        [AllowAnonymous]
-        public IActionResult LogOut()
-        {
-            foreach (var cookie in Request.Cookies.Keys)
-            {
-                Response.Cookies.Delete(cookie);
-            }
-
-            return SignOut(new Microsoft.AspNetCore.Authentication.AuthenticationProperties
-            {
-                RedirectUri = $"{_baseUrl}Support/LoggedOut"
-            }, CookieAuthenticationDefaults.AuthenticationScheme, WsFederationDefaults.AuthenticationScheme);
         }
 
         [AllowAnonymous]

--- a/src/SFA.DAS.Tools.Support.Web/Infrastructure/CustomServiceRole.cs
+++ b/src/SFA.DAS.Tools.Support.Web/Infrastructure/CustomServiceRole.cs
@@ -1,0 +1,12 @@
+﻿using SFA.DAS.DfESignIn.Auth.Interfaces;
+
+namespace SFA.DAS.Tools.Support.Web.Infrastructure
+{
+    /// <summary>
+    /// Class to define the Custom Service Role used in DfESignIn Authentication Service.
+    /// </summary>
+    public class CustomServiceRole : ICustomServiceRole
+    {
+        public string RoleClaimType => "http://service/service";
+    }
+}

--- a/src/SFA.DAS.Tools.Support.Web/SFA.DAS.Tools.Support.Web.csproj
+++ b/src/SFA.DAS.Tools.Support.Web/SFA.DAS.Tools.Support.Web.csproj
@@ -18,7 +18,9 @@
     <PackageReference Include="NLog.Web.AspNetCore" Version="5.0.0" />
     <PackageReference Include="SFA.DAS.CommitmentsV2.Api.Client" Version="8.29.1" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
+    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.25" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.2.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.22.1" />
     <PackageReference Include="WebEssentials.AspNetCore.CdnTagHelpers" Version="1.0.21" />
   </ItemGroup>
 

--- a/src/SFA.DAS.Tools.Support.Web/appsettings.json
+++ b/src/SFA.DAS.Tools.Support.Web/appsettings.json
@@ -6,7 +6,7 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "ConfigNames": "SFA.DAS.Tools.Support",
+  "ConfigNames": "SFA.DAS.Tools.Support,SFA.DAS.Provider.DfeSignIn",
   "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
   "EnvironmentName": "LOCAL",
   "BaseUrl": "localhost:44343",


### PR DESCRIPTION
Story: The purpose of this story is to put behind a feature toggle the DfE Sign in authentication, replacing the existing Pirean, SAML based authentication. When the UseDfESignIn toggle is on -> Start now button should redirect user to DfESignIn Page

https://skillsfundingagency.atlassian.net/browse/FAI-838

Details

1. Extended SFA.DAS.Recruit.QA Config to hold the UseDfeSignIn property. "UseDfeSignIn": true.
2. Added logic/condition in AuthenticationExtension to check if the UseDfeSignIn property is set to true, so that DfESignin happens.
3. Check the Authentication scheme based on UseDfeSignIn property and use the relevant sign-out Authentication Scheme.